### PR TITLE
change ip parsing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.4.1) stable; urgency=medium
+
+  * ip parsing has changed for debian stretch compatibility
+
+ -- Attila Door <a.door@wirenboard.ru>  Thu, 10 May 2018 10:45:51 +0300
+
 wb-rules-system (1.4) stable; urgency=medium
 
   * report Short SN and DTS version via System virtual device

--- a/rules/network.js
+++ b/rules/network.js
@@ -19,7 +19,7 @@ defineVirtualDevice("network", {
 
 
 function _system_update_ip(name, iface) {
-   runShellCommand('ifconfig ' + iface + ' | awk -F \' *|:\' \'/inet addr/{print $4}\'',{
+   runShellCommand('ip addr show ' + iface + ' | grep \"inet\\b\" | awk \'{print $2}\' | cut -d/ -f1',{      
       captureOutput: true,
       exitCallback: function (exitCode, capturedOutput) {
         dev.network[name] = capturedOutput;


### PR DESCRIPTION
ifconfig out has changed in debian stretch and it obtains different output: 


Wheezy:
```
>ifconfig eth0
>eth0      Link encap:Ethernet  HWaddr 02:42:ac:11:00:02  
          inet addr:172.17.0.2  Bcast:172.17.255.255  Mask:255.255.0.0
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:944 errors:0 dropped:0 overruns:0 frame:0
          TX packets:537 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:1295820 (1.2 MiB)  TX bytes:42046 (41.0 KiB)
```

Stretch:
```
>ifconfig eth0
>eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.0.33  netmask 255.255.255.0  broadcast 192.168.0.255
        inet6 fe80::da80:39ff:fee3:6c53  prefixlen 64  scopeid 0x20<link>
        ether d8:80:39:e3:6c:53  txqueuelen 1000  (Ethernet)
        RX packets 2001896  bytes 276188084 (263.3 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 223065  bytes 42319535 (40.3 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
But ip addr show address is the same at both distributions. 