### PR TITLE
renamed rule & virtual device inside for wbmz-battery 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.6.8) stable; urgency=medium
+
+  * renamed rule (and virtual device inside) for wbmz-battery to fit both wbmz2/3 modules
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 30 Sep 2020 16:37:01 +0300
+
 wb-rules-system (1.6.7) stable; urgency=medium
 
   * add reset button settings
@@ -14,7 +20,7 @@ wb-rules-system (1.6.5) stable; urgency=medium
 
   * fix power status for good on WB5 and WB6
   using wbmz2-battery controller data on the latter.
- 
+
   * WB2.8, WBSH 3.5 and WB 4 were not tested and might be broken
 
  -- Evgeny Boger <boger@contactless.ru>  Sun, 19 Apr 2020 17:49:38 +0300
@@ -82,7 +88,7 @@ wb-rules-system (1.4) stable; urgency=medium
 wb-rules-system (1.3.1) stable; urgency=medium
 
   * use board-specific PWM number for buzzer
- 
+
 
  -- Evgeny Boger <boger@contactless.ru>  Mon, 08 Feb 2016 19:20:19 +0300
 

--- a/rules/wbmz-battery.js
+++ b/rules/wbmz-battery.js
@@ -45,8 +45,8 @@ function initDevice(resetButon) {
             type: "pushbutton",
         });
     };
-    defineVirtualDevice("wbmz2-battery", {
-        title: "WBMZ2-BATTERY",
+    defineVirtualDevice("wbmz-battery", {
+        title: "WBMZ-BATTERY",
         cells: cells
     });
 
@@ -57,7 +57,7 @@ function initDevice(resetButon) {
 }
 
 defineRule("_reset_calib", {
-    whenChanged: ["wbmz2-battery/Reset"],
+    whenChanged: ["wbmz-battery/Reset"],
     then: function(newValue, devName, cellName) {
         reset();
     }
@@ -86,18 +86,18 @@ function readI2cData() {
         exitCallback: function(exitCode, capturedOutput) {
             if (!capturedOutput) {
                 /*Записываем в /meta/error значение "r" в случае ошибки чтения данных*/
-                publish("/devices/wbmz2-battery/controls/Current/meta/error", "r", 2, true);
-                publish("/devices/wbmz2-battery/controls/Voltage/meta/error", "r", 2, true);
-                publish("/devices/wbmz2-battery/controls/Temperature/meta/error", "r", 2, true);
-                publish("/devices/wbmz2-battery/controls/Charge/meta/error", "r", 2, true);
-                publish("/devices/wbmz2-battery/controls/Percentage/meta/error", "r", 2, true);
+                publish("/devices/wbmz-battery/controls/Current/meta/error", "r", 2, true);
+                publish("/devices/wbmz-battery/controls/Voltage/meta/error", "r", 2, true);
+                publish("/devices/wbmz-battery/controls/Temperature/meta/error", "r", 2, true);
+                publish("/devices/wbmz-battery/controls/Charge/meta/error", "r", 2, true);
+                publish("/devices/wbmz-battery/controls/Percentage/meta/error", "r", 2, true);
             } else {
                 /*Удаляем значение "r" из /meta/error если данные прочитаны */
-                publish("/devices/wbmz2-battery/controls/Current/meta/error", "", 2, true);
-                publish("/devices/wbmz2-battery/controls/Voltage/meta/error", "", 2, true);
-                publish("/devices/wbmz2-battery/controls/Temperature/meta/error", "", 2, true);
-                publish("/devices/wbmz2-battery/controls/Charge/meta/error", "", 2, true);
-                publish("/devices/wbmz2-battery/controls/Percentage/meta/error", "", 2, true);
+                publish("/devices/wbmz-battery/controls/Current/meta/error", "", 2, true);
+                publish("/devices/wbmz-battery/controls/Voltage/meta/error", "", 2, true);
+                publish("/devices/wbmz-battery/controls/Temperature/meta/error", "", 2, true);
+                publish("/devices/wbmz-battery/controls/Charge/meta/error", "", 2, true);
+                publish("/devices/wbmz-battery/controls/Percentage/meta/error", "", 2, true);
 
                 /*Массив с полученными данными*/
                 var arrayOfData = capturedOutput.split(' ');
@@ -105,17 +105,17 @@ function readI2cData() {
                 /*Сurrent*/
                 var currentRaw = parseInt("0x" + arrayOfData[6] + arrayOfData[5], 16);
                 var voltage_uv = 11.77 * parse2ndComplement(currentRaw); // The battery current is coded in 2’s complement format, and the LSB value is 11.77 uV
-                dev['wbmz2-battery']['Current'] = Math.round(voltage_uv * 1E-6 / rcg_ohm * 1000) / 1000;
+                dev['wbmz-battery']['Current'] = Math.round(voltage_uv * 1E-6 / rcg_ohm * 1000) / 1000;
 
                 /*Voltage*/
                 var voltageRaw = parseInt("0x" + arrayOfData[8] + arrayOfData[7], 16);
                 var voltage_mv = 2.44 * voltageRaw; // The resolution is 2.44 mV for the battery voltage.
-                dev['wbmz2-battery']['Voltage'] = Math.round(voltage_mv * 1E-3 * 1000) / 1000;
+                dev['wbmz-battery']['Voltage'] = Math.round(voltage_mv * 1E-3 * 1000) / 1000;
 
                 /*Temperature*/
                 var temperatureRaw = parseInt("0x" + arrayOfData[10] + arrayOfData[9], 16);
                 var temperature = 0.125 * parse2ndComplement(temperatureRaw); // The resolution is 0.125° C for the temperature.
-                dev['wbmz2-battery']['Temperature'] = Math.round(temperature * 1000) / 1000;
+                dev['wbmz-battery']['Temperature'] = Math.round(temperature * 1000) / 1000;
 
                 /*Charge (mAh)*/
                 var сhargeRaw = parseInt("0x" + arrayOfData[2] + arrayOfData[1], 16);
@@ -134,8 +134,8 @@ function readI2cData() {
                 } else if ((charge_mah - wbmz2_ps.correction) > wbmz2_ps.batteryСapacity) {
                     wbmz2_ps.correction = -(wbmz2_ps.batteryСapacity - charge_mah);
                 }
-                dev['wbmz2-battery']['Charge'] = Math.round((charge_mah - wbmz2_ps.correction) * 100) / 100;
-                dev['wbmz2-battery']['Percentage'] = Math.round((charge_mah - wbmz2_ps.correction) / (wbmz2_ps.batteryСapacity / 100));
+                dev['wbmz-battery']['Charge'] = Math.round((charge_mah - wbmz2_ps.correction) * 100) / 100;
+                dev['wbmz-battery']['Percentage'] = Math.round((charge_mah - wbmz2_ps.correction) / (wbmz2_ps.batteryСapacity / 100));
             }
         }
     });

--- a/rules/wbmz-battery.js
+++ b/rules/wbmz-battery.js
@@ -45,8 +45,8 @@ function initDevice(resetButon) {
             type: "pushbutton",
         });
     };
-    defineVirtualDevice("wbmz-battery", {
-        title: "WBMZ-BATTERY",
+    defineVirtualDevice("battery", {
+        title: "Battery",
         cells: cells
     });
 
@@ -57,7 +57,7 @@ function initDevice(resetButon) {
 }
 
 defineRule("_reset_calib", {
-    whenChanged: ["wbmz-battery/Reset"],
+    whenChanged: ["battery/Reset"],
     then: function(newValue, devName, cellName) {
         reset();
     }
@@ -86,18 +86,18 @@ function readI2cData() {
         exitCallback: function(exitCode, capturedOutput) {
             if (!capturedOutput) {
                 /*Записываем в /meta/error значение "r" в случае ошибки чтения данных*/
-                publish("/devices/wbmz-battery/controls/Current/meta/error", "r", 2, true);
-                publish("/devices/wbmz-battery/controls/Voltage/meta/error", "r", 2, true);
-                publish("/devices/wbmz-battery/controls/Temperature/meta/error", "r", 2, true);
-                publish("/devices/wbmz-battery/controls/Charge/meta/error", "r", 2, true);
-                publish("/devices/wbmz-battery/controls/Percentage/meta/error", "r", 2, true);
+                publish("/devices/battery/controls/Current/meta/error", "r", 2, true);
+                publish("/devices/battery/controls/Voltage/meta/error", "r", 2, true);
+                publish("/devices/battery/controls/Temperature/meta/error", "r", 2, true);
+                publish("/devices/battery/controls/Charge/meta/error", "r", 2, true);
+                publish("/devices/battery/controls/Percentage/meta/error", "r", 2, true);
             } else {
                 /*Удаляем значение "r" из /meta/error если данные прочитаны */
-                publish("/devices/wbmz-battery/controls/Current/meta/error", "", 2, true);
-                publish("/devices/wbmz-battery/controls/Voltage/meta/error", "", 2, true);
-                publish("/devices/wbmz-battery/controls/Temperature/meta/error", "", 2, true);
-                publish("/devices/wbmz-battery/controls/Charge/meta/error", "", 2, true);
-                publish("/devices/wbmz-battery/controls/Percentage/meta/error", "", 2, true);
+                publish("/devices/battery/controls/Current/meta/error", "", 2, true);
+                publish("/devices/battery/controls/Voltage/meta/error", "", 2, true);
+                publish("/devices/battery/controls/Temperature/meta/error", "", 2, true);
+                publish("/devices/battery/controls/Charge/meta/error", "", 2, true);
+                publish("/devices/battery/controls/Percentage/meta/error", "", 2, true);
 
                 /*Массив с полученными данными*/
                 var arrayOfData = capturedOutput.split(' ');
@@ -105,17 +105,17 @@ function readI2cData() {
                 /*Сurrent*/
                 var currentRaw = parseInt("0x" + arrayOfData[6] + arrayOfData[5], 16);
                 var voltage_uv = 11.77 * parse2ndComplement(currentRaw); // The battery current is coded in 2’s complement format, and the LSB value is 11.77 uV
-                dev['wbmz-battery']['Current'] = Math.round(voltage_uv * 1E-6 / rcg_ohm * 1000) / 1000;
+                dev['battery']['Current'] = Math.round(voltage_uv * 1E-6 / rcg_ohm * 1000) / 1000;
 
                 /*Voltage*/
                 var voltageRaw = parseInt("0x" + arrayOfData[8] + arrayOfData[7], 16);
                 var voltage_mv = 2.44 * voltageRaw; // The resolution is 2.44 mV for the battery voltage.
-                dev['wbmz-battery']['Voltage'] = Math.round(voltage_mv * 1E-3 * 1000) / 1000;
+                dev['battery']['Voltage'] = Math.round(voltage_mv * 1E-3 * 1000) / 1000;
 
                 /*Temperature*/
                 var temperatureRaw = parseInt("0x" + arrayOfData[10] + arrayOfData[9], 16);
                 var temperature = 0.125 * parse2ndComplement(temperatureRaw); // The resolution is 0.125° C for the temperature.
-                dev['wbmz-battery']['Temperature'] = Math.round(temperature * 1000) / 1000;
+                dev['battery']['Temperature'] = Math.round(temperature * 1000) / 1000;
 
                 /*Charge (mAh)*/
                 var сhargeRaw = parseInt("0x" + arrayOfData[2] + arrayOfData[1], 16);
@@ -134,8 +134,8 @@ function readI2cData() {
                 } else if ((charge_mah - wbmz2_ps.correction) > wbmz2_ps.batteryСapacity) {
                     wbmz2_ps.correction = -(wbmz2_ps.batteryСapacity - charge_mah);
                 }
-                dev['wbmz-battery']['Charge'] = Math.round((charge_mah - wbmz2_ps.correction) * 100) / 100;
-                dev['wbmz-battery']['Percentage'] = Math.round((charge_mah - wbmz2_ps.correction) / (wbmz2_ps.batteryСapacity / 100));
+                dev['battery']['Charge'] = Math.round((charge_mah - wbmz2_ps.correction) * 100) / 100;
+                dev['battery']['Percentage'] = Math.round((charge_mah - wbmz2_ps.correction) / (wbmz2_ps.batteryСapacity / 100));
             }
         }
     });


### PR DESCRIPTION
У нас есть 2 модуля батарейки: wbmz2-battery и wbmz3-battery. Внутри они одинаковые, но wbmz3 - для wb6.7.x. 
В софте решили называть новую батарейку wbmz3-battery ([PR](https://github.com/wirenboard/wb-hwconf-manager/pull/32)) => в hwconf'e выбрана wbmz3-battery, а в веб-интерфейсе красуется WBMZ2-BATTERY, что нелогично.
Предлагаю переименовать виртуальный девайс на WBMZ-BATTERY, чтобы никого не смущать.
![2020-09-30-165107_420x335_scrot](https://user-images.githubusercontent.com/25829054/94694790-e1bbc600-033d-11eb-9c04-79786559dee6.png)

Альтернативное решение - писать из hwconf'a куда-нибудь в ноду wirenboard, какая именно батарейка у нас, а потом - правилом читать оттуда и брать название виртуал-девайса. Но есть ли смысл всё усложнять?
