### PR TITLE
fixed power_status rule

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.6.9) stable; urgency=medium
+
+  * fixed power_status rule to support wbmz2/3 modules
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 09 Dec 2020 14:34:51 +0300
+
 wb-rules-system (1.6.8) stable; urgency=medium
 
   * renamed rule (and virtual device inside) for wbmz-battery to fit both wbmz2/3 modules

--- a/rules/power_status.js
+++ b/rules/power_status.js
@@ -31,7 +31,7 @@ defineRule("_system_track_vin", {
     }
 });
 
-/* Power status reporting for Wiren Board 5.x is based on 
+/* Power status reporting for Wiren Board 5.x is based on
     1) Vin value (normally above 7V)
     2) Battery present status
     3) Battery charging status
@@ -44,34 +44,34 @@ spawn('bash', ['-c', '. /etc/wb_env.sh && wb_source of && of_machine_match "cont
             defineRule("_system_wb5_track_power_status", {
                 whenChanged: [
                     function() { // get power status
-                        // we don't expect the voltage to go up and down 
+                        // we don't expect the voltage to go up and down
                         //  around the threshold, so no hysteresis here
-                        return dev["wb-gpio/BATTERY_PRESENT"] && !dev["wb-gpio/BATTERY_CHARGING"] 
+                        return dev["wb-gpio/BATTERY_PRESENT"] && !dev["wb-gpio/BATTERY_CHARGING"]
                             && (dev["wb-adc/Vin"] < 5.0);
                     }
                 ],
                 then: function (newValue, devName, cellName) {
                     dev["power_status/working on battery"] = newValue;
                 }
-            });            
+            });
         }
     }
 });
 
 
-/* Power status for Wiren Board 6+ with wbmz2-battery module */
+/* Power status for Wiren Board 6.x/6.7.x with wbmzX-battery module */
 
 var lastTriggeredCurrent = null;
 var currentHysteresis = 0.01;
 var dischargingThreshold = -0.02;
 
 defineRule("_system_wbmz2_power_status", {
-    whenChanged: ["wbmz2-battery/Current"],
+    whenChanged: ["battery/Current"],
     then: function (newValue, devName, cellName) {
         if (lastTriggeredCurrent != null)
             if (Math.abs(newValue - lastTriggeredCurrent) < currentHysteresis)
                 return;
-        
+
         var newStatus = (newValue < dischargingThreshold);
 
         if  (dev["power_status/working on battery"] != newStatus) {
@@ -80,4 +80,3 @@ defineRule("_system_wbmz2_power_status", {
         }
     }
 });
-


### PR DESCRIPTION
у виртуального устройства батарейки поменялся топик, а power_monitor смотрел в старый => когда питание выключалось, не было галочки "working_on_battery"