### PR TITLE
system.js: remove newlines in capturedOutput

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules-system (1.6.11) stable; urgency=medium
+
+  * fix 'Development release' flag, it was broken on stable releases
+  * trim newlines in System device controls
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 26 Apr 2021 17:02:21 +0300
+
 wb-rules-system (1.6.10) unstable; urgency=medium
 
   * add release info in system device

--- a/rules/system.js
+++ b/rules/system.js
@@ -43,7 +43,7 @@ function _system_update_uptime() {
   runShellCommand('awk \'{print int($1/86400)\"d \"int(($1%86400)/3600)\"h \"int(($1%3600)/60)\"m\"}\' /proc/uptime', {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
-      dev.system["Current uptime"] = capturedOutput;
+      dev.system["Current uptime"] = capturedOutput.trim();
     }
   });
 };
@@ -63,7 +63,7 @@ function fillWirenboardNodeProperty(controlName, propertyName) {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
       if (exitCode == 0) {
-        dev.system[controlName] = capturedOutput;
+        dev.system[controlName] = capturedOutput.trim();
       }
     }
   });
@@ -73,7 +73,7 @@ function getReleaseInfoProperty(property, cell) {
   spawn('sh', ['-c', '. /usr/lib/wb-release && echo $' + property], {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
-      dev.system[cell] = capturedOutput;
+      dev.system[cell] = capturedOutput.trim();
     }
   });
 }
@@ -105,14 +105,14 @@ function initSystemDevice(hasWirenboardNode) {
   spawn('cat', ['/etc/wb-fw-version'], {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
-      dev.system["Firmware version"] = capturedOutput;
+      dev.system["Firmware version"] = capturedOutput.trim();
     }
   });
 
   spawn('cat', ['/var/lib/wirenboard/short_sn.conf'], {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
-      dev.system["Short SN"] = capturedOutput;
+      dev.system["Short SN"] = capturedOutput.trim();
     }
   });
 
@@ -130,7 +130,7 @@ function initSystemDevice(hasWirenboardNode) {
   spawn('sh', ['-c', '. /usr/lib/wb-release && echo $REPO_PREFIX'], {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
-      dev.system["Development release"] = (capturedOutput !== "");
+      dev.system["Development release"] = (capturedOutput.trim() !== "");
     }
   });
 


### PR DESCRIPTION
It fixes 'Development release' flag in MQTT which was always true because of a newline symbol in output.

Also, trimmed newline symbols in other controls with capturedOutput.