### PR TITLE
Fix wb-rules restart (#36114)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules-system (1.6.13) stable; urgency=medium
+
+  * use deb-systemd-invoke restart wb-rules instead of service wb-rules
+    restart to build rootfs properly after removing wb-rules initscript
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 01 Jun 2021 00:09:26 +0300
+
 wb-rules-system (1.6.12) stable; urgency=medium
 
   * remove unnecessary fields from System device

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-invoke-rc.d wb-rules restart
+deb-systemd-invoke restart wb-rules
 
 #DEBHELPER#
 


### PR DESCRIPTION
Старый скрипт падает в сочетании с wb-rules 2.7.0, где вместо init-скрипта сервис systemd