### PR TITLE
Ignoring too high erroneous discharge currents

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.8.1) stable; urgency=medium
+
+  * Ignoring too high erroneous discharge currents
+
+ -- Dmitry Vorobjev <d.vorobjev@wirenboard.ru>  Mon, 07 Mar 2022 17:03:19 +0300
+
 wb-rules-system (1.8.0) stable; urgency=medium
 
   * add support for battery and supercap modules on WB7. It's actually

--- a/rules/wbmz-battery.js
+++ b/rules/wbmz-battery.js
@@ -125,10 +125,12 @@ function readI2cData() {
 
                 /*Сurrent*/
                 var currentRaw = parseInt("0x" + arrayOfData[6] + arrayOfData[5], 16);
-                var voltage_uv = 11.77 * parse2ndComplement(currentRaw); // The battery current is coded in 2’s complement format, and the LSB value is 11.77 uV
-                var current = Math.round(voltage_uv * 1E-6 / rcg_ohm * 1000) / 1000;
-                dev['battery']['Current'] = current;
-                updatePowerStatus(current);
+                if (currentRaw < 0x4000) {
+                    var voltage_uv = 11.77 * parse2ndComplement(currentRaw); // The battery current is coded in 2’s complement format, and the LSB value is 11.77 uV
+                    var current = Math.round(voltage_uv * 1E-6 / rcg_ohm * 1000) / 1000;
+                    dev['battery']['Current'] = current;
+                    updatePowerStatus(current);
+                }
 
                 /*Voltage*/
                 var voltageRaw = parseInt("0x" + arrayOfData[8] + arrayOfData[7], 16);


### PR DESCRIPTION
Команда
i2cdump -y 7 0x70 s | grep 00: | sed -e 's/00: //g' -e 's/    .*//g'

которая вызывается из скрипта /usr/share/wb-rules-system/rules/wbmz-battery.js, периодически возвращает нереально большие значения тока разряда аккумулятора (FFFF, или близкие к этому значения).
Как вариант решения проблемы - игнорировать нереально большие значения тока разряда аккумулятора.