### PR TITLE
wbmz-battery: use consecutive bytes read mode to get status

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-rules-system (1.8.1) stable; urgency=medium
+
+  * wbmz-battery: use consecutive bytes read mode to get status.
+    This should fix periodic read errors which led to incorrect values
+    published in Battery device
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 07 Jun 2022 23:19:07 +0300
+
 wb-rules-system (1.8.0) stable; urgency=medium
 
   * add support for battery and supercap modules on WB7. It's actually

--- a/rules/wbmz-battery.js
+++ b/rules/wbmz-battery.js
@@ -102,7 +102,7 @@ function parse2ndComplement16(raw) {
 
 function readI2cData() {
     /*Читаем данные*/
-    runShellCommand("i2cdump -y {} 0x70 s | grep 00: | sed -e 's/00: //g' -e 's/    .*//g'".format(config.bus), {
+    runShellCommand("i2cdump -y -r 0x01-0x0C {} 0x70 c | grep 00: | sed -e 's/00: //g' -e 's/    .*//g'".format(config.bus), {
         captureOutput: true,
         exitCallback: function(exitCode, capturedOutput) {
             if (!capturedOutput) {
@@ -121,7 +121,7 @@ function readI2cData() {
                 publish("/devices/battery/controls/Percentage/meta/error", "", 2, true);
 
                 /*Массив с полученными данными*/
-                var arrayOfData = capturedOutput.split(' ');
+                var arrayOfData = capturedOutput.trim().split(' ');
 
                 /*Сurrent*/
                 var currentRaw = parseInt("0x" + arrayOfData[6] + arrayOfData[5], 16);


### PR DESCRIPTION
This should fix periodic read errors which led to incorrect values published in Battery device.

Replaces #26, #25 