### PR TITLE
hwmon: remove unnecessary string to int convertion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.8.2) stable; urgency=medium
+
+  * hwmon: remove unnecessary string to int convertion (thanks nlef!)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 15 Sep 2022 18:18:00 +0300
+
 wb-rules-system (1.8.1) stable; urgency=medium
 
   * wbmz-battery: use consecutive bytes read mode to get status.

--- a/rules/hwmon.js
+++ b/rules/hwmon.js
@@ -81,7 +81,7 @@ function readChannel(path, controlName) {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
       if (exitCode == 0) {
-        dev['hwmon'][controlName] = parseFloat((parseInt(capturedOutput ) * 0.001).toFixed(3));
+        dev['hwmon'][controlName] = (parseFloat(capturedOutput) * 0.001).toFixed(3);
       }
     }
   });


### PR DESCRIPTION
Rebase of #10 with debian/changelog entry, thanks [nlef](https://github.com/nlef)