### PR TITLE
hwmon: fix conversion warning

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.8.3) stable; urgency=medium
+
+  * hwmon: fix conversion warning, revert 1.8.2 changes
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 11 Oct 2022 15:36:04 +0500
+
 wb-rules-system (1.8.2) stable; urgency=medium
 
   * hwmon: remove unnecessary string to int convertion (thanks nlef!)

--- a/rules/hwmon.js
+++ b/rules/hwmon.js
@@ -81,7 +81,7 @@ function readChannel(path, controlName) {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
       if (exitCode == 0) {
-        dev['hwmon'][controlName] = (parseFloat(capturedOutput) * 0.001).toFixed(3);
+        dev['hwmon'][controlName] = parseFloat((parseInt(capturedOutput) * 0.001).toFixed(3));
       }
     }
   });


### PR DESCRIPTION
* revert 1.8.2 changes
* wb-rules has internal type checking and warns about setting strings to controls declared as floats

https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/53812/