### PR TITLE
Fix buzzer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.9.1) stable; urgency=medium
+
+  * Fix buzzer
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 12 Jan 2023 20:11:00 +0400
+
 wb-rules-system (1.9.0) stable; urgency=medium
 
   * network: split 'Active Connection Name' control into 'Active Connections'

--- a/rules/buzzer.js
+++ b/rules/buzzer.js
@@ -30,7 +30,7 @@
         pwm_number = parseInt(capturedOutput);
       }
 
-      runShellCommand("[ -e {0}/pwm{1} ] || echo {1} > {0}/export".format(pwm_sys, pwm_number));
+      runShellCommand("[ -e {}/pwm{} ] || echo {} > {}/export".format(pwm_sys, pwm_number, pwm_number, pwm_sys));
     }
   });
 


### PR DESCRIPTION
Стандартный JS `"{0}".format(...)`-синтаксис не поддерживается wb-rules.