### PR TITLE
network: cells namings fixup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-rules-system (1.9.2) stable; urgency=medium
+
+  * network: cell namings fixup to preserve compatibility with homeui dashboards
+    "Wi-Fi 1 ..." -> "Wi-Fi ..."
+    "Ethernet 1 ..." -> "Ethernet ..."
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 09 Mar 2023 15:30:19 +0400
+
 wb-rules-system (1.9.1) stable; urgency=medium
 
   * Fix buzzer

--- a/rules/network.js
+++ b/rules/network.js
@@ -1,6 +1,9 @@
 var checkAddress = "1.1.1.1";
 
 defineVirtualDevice("network", {
+  /*
+  While editing cell names, mind compatibility with existing homeui dashboards!
+  */
   title: "Network",
   cells: {
     "Active Connections": {
@@ -11,7 +14,7 @@ defineVirtualDevice("network", {
       type: "text",
       value: ""
     },
-    "Ethernet 1 IP": {
+    "Ethernet IP": {
       type: "text",
       value: ""
     },
@@ -19,7 +22,7 @@ defineVirtualDevice("network", {
       type: "text",
       value: ""
     },
-    "Wi-Fi 1 IP": {
+    "Wi-Fi IP": {
       type: "text",
       value: ""
     },
@@ -31,7 +34,7 @@ defineVirtualDevice("network", {
       type: "text",
       value: ""
     },
-    "Ethernet 1 IP Online Status": {
+    "Ethernet IP Online Status": {
       type: "switch",
       value: false,
       readonly: true
@@ -45,7 +48,7 @@ defineVirtualDevice("network", {
       type: "text",
       value: ""
     },
-    "Wi-Fi 1 IP Online Status": {
+    "Wi-Fi IP Online Status": {
       type: "switch",
       value: false,
       readonly: true
@@ -110,9 +113,9 @@ function _current_active_connection() {
 };
 
 function _system_update_ip_all() {
-  _system_update_ip("Ethernet 1 IP", "eth0");
+  _system_update_ip("Ethernet IP", "eth0");
   _system_update_ip("Ethernet 2 IP", "eth1");
-  _system_update_ip("Wi-Fi 1 IP", "wlan0");
+  _system_update_ip("Wi-Fi IP", "wlan0");
   _system_update_ip("Wi-Fi 2 IP", "wlan1");
   _system_update_ip("GPRS IP", "ppp0");
   _current_active_connection();


### PR DESCRIPTION
примерно в январе в репозиторий попал код, ломающий дашборды в homeui
![2023-03-09_16-11-48](https://user-images.githubusercontent.com/25829054/224037098-3e0c98f4-efc9-4922-9ce8-ec5bde2bbedf.png)

это происходит из-за расхождения имён в virtual-device и конфигах дашбордов
посовещавшись, решили пофиксить на стороне wb-rules-system, т.к. сложно поддерживать дашборды, если пользователь там уже что-то поменял

результат
![2023-03-09_15-45-56](https://user-images.githubusercontent.com/25829054/224037568-4acad25f-2313-4304-a11e-8eed5dd1d4c1.png)
![2023-03-09_15-45-49](https://user-images.githubusercontent.com/25829054/224037572-1b223ccd-29b7-4c1c-8331-139cfaa422c7.png)
