### PR TITLE
Remove battery charging manually switching

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.9.6) stable; urgency=medium
+
+  * Remove battery charging manually switching
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Fri, 28 Jul 2023 10:36:13 +0300
+
 wb-rules-system (1.9.5) stable; urgency=medium
 
   * Format source code. No functional changes

--- a/rules/power-class-battery.js
+++ b/rules/power-class-battery.js
@@ -113,6 +113,7 @@ function removeControlIfExists(vdevObj, controlName) {
   }
 }
 
+var chargingStateSetTime = null;
 function updateChargingControl(vdevObj, psData) {
   if (!psData.hasOwnProperty('STATUS')) return;
 
@@ -121,7 +122,7 @@ function updateChargingControl(vdevObj, psData) {
   var charging = false;
   if (psData['STATUS'] == 'Charging') charging = true;
 
-  createControlOrSetValue(vdevObj, 'Charging', { type: 'switch', readonly: 'true' }, charging);
+  createControlOrSetValue(vdevObj, 'Charging', { type: 'switch', readonly: true }, charging);
 }
 
 function createVdevOnce() {

--- a/rules/power-class-battery.js
+++ b/rules/power-class-battery.js
@@ -113,31 +113,6 @@ function removeControlIfExists(vdevObj, controlName) {
   }
 }
 
-var chargingStateSetTime = null;
-defineRule({
-  whenChanged: 'battery/Charging',
-  then: function (newValue) {
-    log('changed {}'.format(newValue));
-    var batName = powerSupplyNamesByType['Battery'];
-    var newState;
-    if (newValue) {
-      newState = 'Charging';
-    } else {
-      newState = 'Not charging';
-    }
-    runShellCommand("echo '{}' > /sys/class/power_supply/{}/status".format(newState, batName), {
-      exitCallback: function (exitCode, capturedOutput) {
-        if (exitCode == 0) {
-          chargingStateSetTime = new Date();
-        } else {
-          // error writing new status, revert state
-          getControl('battery/Charging').setValue({ value: !newValue, notify: false });
-        }
-      },
-    });
-  },
-});
-
 function updateChargingControl(vdevObj, psData) {
   if (!psData.hasOwnProperty('STATUS')) return;
 
@@ -146,7 +121,7 @@ function updateChargingControl(vdevObj, psData) {
   var charging = false;
   if (psData['STATUS'] == 'Charging') charging = true;
 
-  createControlOrSetValue(vdevObj, 'Charging', { type: 'switch' }, charging);
+  createControlOrSetValue(vdevObj, 'Charging', { type: 'switch', readonly: 'true' }, charging);
 }
 
 function createVdevOnce() {


### PR DESCRIPTION
Убрала ручное переключение зарядки суперкапа. Если пробовать руками из консоли записать в статус Charging, то оно говорит что не хватает прав. Вероятно, так больше нельзя делать. Оставила только опрос состояния в режиме readonly