### PR TITLE
buzzer: fix PWM polarity on WB7 and WB8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.11.2) stable; urgency=medium
+
+  * buzzer: fix PWM polarity on wb7 and wb8
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Thu, 29 Aug 2024 17:52:09 +0500
+
 wb-rules-system (1.11.1) stable; urgency=medium
 
   * power-class-battery: add control title translations


### PR DESCRIPTION
Из-за неправильной полярности чуть больше грелся транзистор и пищалка, это никому не нравилось, хотя к реальным проблемам вроде не приводило.

Заодно разложил более аккуратно вызовы runShellCommand, чтобы они точно запускались друг за другом, а не параллельно. По ощущениям после этого на wb8 стало меньше глюков при частом включении/выключении и сразу после запуска контроллера.