### PR TITLE
Add firmware.js rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,15 +6,6 @@
 *.debhelper.log
 *.debhelper
 *.substvars
-*.o
-*/debian/libmosquitto-dev/*
-*/debian/libmosquitto1/*
-*/debian/libmosquittopp-dev/*
-*/debian/libmosquittopp1/*
-*/debian/mosquitto-clients/*
-*/debian/mosquitto-dbg/*
-*/debian/mosquitto-dev/*
-*/debian/mosquitto/*
 */debian/wb-rules-system/*
 *.swp
 *.un~
@@ -23,14 +14,6 @@
 **/debian/*.debhelper
 **/debian/*.debhelper.log
 **/debian/*.substvars
-
-utils/debian/wb-utils/
-wb-utils_*.deb
-wb-utils_*.changes
-
-configs/debian/wb-configs/
-wb-configs_*.*
-*.pyc
 
 .tern-port
 debian/wb-rules-system

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.12.0) stable; urgency=medium
+
+  * Add firmware.js rule
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 23 Sep 2024 11:30:00 +0400
+
 wb-rules-system (1.11.3) stable; urgency=medium
 
   * buzzer: fix PWM polarity on wb7 and wb8

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/wirenboard/wb-rules-system/
 
 Package: wb-rules-system
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, wb-rules (>= 2.20.0~~), wb-utils (>= 2.1)
+Depends: ${shlibs:Depends}, ${misc:Depends}, wb-rules (>= 2.20.0~~), wb-utils (>= 4.24.0~~)
 Recommends: linux-image-wb2 | linux-image-wb6 (>= 4.9+wb20180729224630) | linux-image-wb7,
             wb-hwconf-manager (>= 1.30.1), wb-release-info
 Description: Default system rules for Wiren Board

--- a/rules/firmware.js
+++ b/rules/firmware.js
@@ -10,7 +10,7 @@ function publishFitFileInfo(filePath, presentTopic, compatibilityTopic) {
         captureOutput: true,
         exitCallback: function (exitCode, capturedOutput) {
           if (exitCode != 0) return;
-          publish(compatibilityTopic, capturedOutput, 0, true);
+          publish(compatibilityTopic, capturedOutput.trim(), 0, true);
         }
       });
     }

--- a/rules/firmware.js
+++ b/rules/firmware.js
@@ -1,0 +1,32 @@
+function publishFitFileInfo(filePath, presentTopic, compatibilityTopic) {
+  runShellCommand('test -f {}'.format(filePath), {
+    exitCallback: function (exitCode) {
+      if (exitCode != 0) {
+        publish(presentTopic, 'false', 0, true);
+        return;
+      }
+      publish(presentTopic, 'true', 0, true);
+      runShellCommand('FIT={} wb-fw-compatible'.format(filePath), {
+        captureOutput: true,
+        exitCallback: function (exitCode, capturedOutput) {
+          if (exitCode != 0) return;
+          publish(compatibilityTopic, capturedOutput, 0, true);
+        }
+      });
+    }
+  });
+}
+
+publishFitFileInfo(
+  '/mnt/data/.wb-restore/factoryreset.fit',
+  '/firmware/fits/factoryreset/present',
+  '/firmware/fits/factoryreset/compatibility'
+);
+
+publishFitFileInfo(
+  '/mnt/data/.wb-restore/factoryreset.original.fit',
+  '/firmware/fits/factoryreset-original/present',
+  '/firmware/fits/factoryreset-original/compatibility'
+);
+
+publish('/firmware/status', 'IDLE', 0, true);


### PR DESCRIPTION
Testing set:
```sh
echo "deb http://deb.wirenboard.com/all experimental.mosquitto-restart main" > /etc/apt/sources.list.d/mosquitto-restart.list
```

Check it out:
```sh
mqtt-get-dump /firmware/#
/firmware/fits/factoryreset-original/present	false
/firmware/fits/factoryreset/present	true
/firmware/fits/factoryreset/compatibility	+single-rootfs +fit-factory-reset +force-repartition +repartition-ramsize-fix +update-from-cloud
/firmware/status	IDLE
```