### PR TITLE
Fix on fly changing of buzzer parameters on WB 8.4.x

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.12.5) stable; urgency=medium
+
+  * Fix on fly changing of buzzer parameters on WB 8.4.x
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 24 Apr 2025 10:07:29 +0500
+
 wb-rules-system (1.12.4) stable; urgency=medium
 
   * Fix power status updating at startup


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
На WB 8.4.x при изменении настроек пищалки, при самой включенной пищалке, звук пропадал.
Для пищалки используется драйвер PWM из проца. Посмотрел в код и в даташит, с ходу ничего криминального не увидел. Не хочу тратить время на эксперименты с драйвером. Сделал выключение pwm перед изменением настроек.

___________________________________
**Что поменялось для пользователей:**
Двигаешь ползуно - звук меняется.

___________________________________
**Как проверял/а:**
Подвигал ползунки

