### PR TITLE
Feature: add new vd with system time and tz

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-rules-system (1.12.6) stable; urgency=medium
+wb-rules-system (1.13.0) stable; urgency=medium
 
   * Add system time virtual device in webui
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-rules-system (1.13.0) stable; urgency=medium
 
   * Add system time virtual device in webui
 
- -- Ivan Praulov <ivan.praulov@wirenboard.com>  Fri, 14 Nov 2025 10:50:00 +0500
+ -- Ivan Praulov <ivan.praulov@wirenboard.com>  Fri, 18 Nov 2025 16:55:00 +0500
 
 wb-rules-system (1.12.5) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.12.6) stable; urgency=medium
+
+  * Add system time virtual device in webui
+
+ -- Ivan Praulov <ivan.praulov@wirenboard.com>  Fri, 14 Nov 2025 10:50:00 +0500
+
 wb-rules-system (1.12.5) stable; urgency=medium
 
   * Fix on fly changing of buzzer parameters on WB 8.4.x

--- a/rules/system.js
+++ b/rules/system.js
@@ -4,16 +4,6 @@ var systemCells = {
     type: 'text',
     value: '0',
   },
-  'Timezone': {
-    title: { en: 'Timezone', ru: 'Часовая зона' },
-    type: 'text',
-    value: '',
-  },
-  'Current time': {
-    title: { en: 'Current time', ru: 'Текущее время' },
-    type: 'text',
-    value: '',
-  },
   'Short SN': {
     title: { en: 'Short SN', ru: 'Серийный номер' },
     type: 'text',
@@ -50,26 +40,6 @@ function _system_update_uptime() {
       },
     }
   );
-}
-
-function _system_update_datetime() {
-  runShellCommand('date +"%Z (UTC%z)"', {
-    captureOutput: true,
-    exitCallback: function (exitCode, capturedOutput) {
-      if (exitCode == 0) {
-        dev.system['Timezone'] = capturedOutput.trim();
-      }
-    }
-  });
-
-  runShellCommand('date +"%Y-%m-%d %H:%M"', {
-    captureOutput: true,
-    exitCallback: function (exitCode, capturedOutput) {
-      if (exitCode == 0) {
-        dev.system['Current time'] = capturedOutput.trim();
-      }
-    }
-  });
 }
 
 spawn('sh', ['-c', '[ -d /proc/device-tree/wirenboard ]'], {
@@ -139,9 +109,6 @@ function initSystemDevice(hasWirenboardNode) {
 
   _system_update_uptime();
   setInterval(_system_update_uptime, 60000);
-
-  _system_update_datetime();
-  setInterval(_system_update_datetime, 60000);
 
   spawn('cat', ['/var/lib/wirenboard/short_sn.conf'], {
     captureOutput: true,

--- a/rules/system.js
+++ b/rules/system.js
@@ -4,6 +4,16 @@ var systemCells = {
     type: 'text',
     value: '0',
   },
+  'Timezone': {
+    title: { en: 'Timezone', ru: 'Часовая зона' },
+    type: 'text',
+    value: '',
+  },
+  'Current time': {
+    title: { en: 'Current time', ru: 'Текущее время' },
+    type: 'text',
+    value: '',
+  },
   'Short SN': {
     title: { en: 'Short SN', ru: 'Серийный номер' },
     type: 'text',
@@ -40,6 +50,26 @@ function _system_update_uptime() {
       },
     }
   );
+}
+
+function _system_update_datetime() {
+  runShellCommand('date +"%Z (UTC%z)"', {
+    captureOutput: true,
+    exitCallback: function (exitCode, capturedOutput) {
+      if (exitCode == 0) {
+        dev.system['Timezone'] = capturedOutput.trim();
+      }
+    }
+  });
+
+  runShellCommand('date +"%Y-%m-%d %H:%M"', {
+    captureOutput: true,
+    exitCallback: function (exitCode, capturedOutput) {
+      if (exitCode == 0) {
+        dev.system['Current time'] = capturedOutput.trim();
+      }
+    }
+  });
 }
 
 spawn('sh', ['-c', '[ -d /proc/device-tree/wirenboard ]'], {
@@ -109,6 +139,9 @@ function initSystemDevice(hasWirenboardNode) {
 
   _system_update_uptime();
   setInterval(_system_update_uptime, 60000);
+
+  _system_update_datetime();
+  setInterval(_system_update_datetime, 60000);
 
   spawn('cat', ['/var/lib/wirenboard/short_sn.conf'], {
     captureOutput: true,

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -51,9 +51,12 @@ function _system_time_update_datetime() {
         // Get new time (already next minute)
         var newNow = new Date();
         
+        var dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        var dayName = dayNames[newNow.getDay()];
+        
         var dateStr = newNow.getFullYear() + '-' + 
                     _padZero(newNow.getMonth() + 1) + '-' + 
-                    _padZero(newNow.getDate());
+                    _padZero(newNow.getDate()) + ' ' + dayName;
         
         var timeStr = _padZero(newNow.getHours()) + ':' + 
                     _padZero(newNow.getMinutes());

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -5,19 +5,19 @@
  */
 
 var systemTimeCells = {
-  'Timezone': {
+  'timezone': {
     title: { en: 'Timezone', ru: 'Часовая зона' },
     type: 'text',
     order: 3,
     value: '',
   },
-  'Current date': {
+  'current_date': {
     title: { en: 'Current date', ru: 'Текущая дата' },
     type: 'text',
     order: 1,
     value: '',
   },
-  'Current time': {
+  'current_time': {
     title: { en: 'Current time', ru: 'Текущее время' },
     type: 'text',
     order: 2,
@@ -50,15 +50,15 @@ function _system_time_update_datetime() {
 
     var timezoneStr = _formatTimezone(now.getTimezoneOffset());
     
-    dev['system-time']['Timezone'] = timezoneStr;
-    dev['system-time']['Current date'] = dateStr;
-    dev['system-time']['Current time'] = timeStr;
+    dev['system_time']['timezone'] = timezoneStr;
+    dev['system_time']['current_date'] = dateStr;
+    dev['system_time']['current_time'] = timeStr;
   } catch (error) {
     log.error('system_time: Failed to update datetime: {}', error.message);
   }
 }
 
-defineVirtualDevice('system-time', {
+defineVirtualDevice('system_time', {
   title: { en: 'System Time', ru: 'Системное время' },
   cells: systemTimeCells,
 });

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -59,7 +59,7 @@ var systemTimeCells = {
     value: '',
   },
   'timezone': {
-    title: { en: 'Timezone', ru: 'Часовая зона' },
+    title: { en: 'Timezone', ru: 'Часовой пояс' },
     type: 'text',
     order: 4,
     value: '',

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -1,39 +1,61 @@
+/**
+ * @file system_time.js - ES5 module for wb-rules v2.35
+ * @description system time virtual device module
+ * @author Ivan Praulov <ivan.praulov@wirenboard.com>
+ */
+
 var systemTimeCells = {
   'Timezone': {
     title: { en: 'Timezone', ru: 'Часовая зона' },
     type: 'text',
+    order: 3,
     value: '',
   },
   'Current date': {
     title: { en: 'Current date', ru: 'Текущая дата' },
     type: 'text',
+    order: 1,
     value: '',
   },
   'Current time': {
     title: { en: 'Current time', ru: 'Текущее время' },
     type: 'text',
+    order: 2,
     value: '',
   },
 };
 
+function _padZero(num) {
+  var str = String(num);
+  return str.length < 2 ? '0' + str : str;
+}
+
+function _formatTimezone(offset) {
+  var hours = Math.abs(Math.floor(offset / 60));
+  var minutes = Math.abs(offset % 60);
+  var sign = offset <= 0 ? '+' : '-';
+  return 'UTC' + sign + _padZero(hours) + _padZero(minutes);
+}
+
 function _system_time_update_datetime() {
-  runShellCommand('date +"%Z (UTC%z)|%Y-%m-%d|%H:%M"', {
-    captureOutput: true,
-    exitCallback: function (exitCode, capturedOutput) {
-      if (exitCode == 0) {
-        var parts = capturedOutput.trim().split('|');
-        if (parts.length === 3) {
-          dev['system-time']['Timezone'] = parts[0];
-          dev['system-time']['Current date'] = parts[1];
-          dev['system-time']['Current time'] = parts[2];
-        } else {
-          log.error('system_time: Failed to parse date output, expected 3 parts but got {}: "{}"', parts.length, capturedOutput.trim());
-        }
-      } else {
-        log.error('system_time: Date command failed with exit code {}, output: "{}"', exitCode, capturedOutput.trim());
-      }
-    }
-  });
+  try {
+    var now = new Date();
+    
+    var dateStr = now.getFullYear() + '-' + 
+                _padZero(now.getMonth() + 1) + '-' + 
+                _padZero(now.getDate());
+    
+    var timeStr = _padZero(now.getHours()) + ':' + 
+                _padZero(now.getMinutes());
+
+    var timezoneStr = _formatTimezone(now.getTimezoneOffset());
+    
+    dev['system-time']['Timezone'] = timezoneStr;
+    dev['system-time']['Current date'] = dateStr;
+    dev['system-time']['Current time'] = timeStr;
+  } catch (error) {
+    log.error('system_time: Failed to update datetime: {}', error.message);
+  }
 }
 
 defineVirtualDevice('system-time', {

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -1,0 +1,45 @@
+var systemTimeCells = {
+  'Timezone': {
+    title: { en: 'Timezone', ru: 'Часовая зона' },
+    type: 'text',
+    value: '',
+  },
+  'Current date': {
+    title: { en: 'Current date', ru: 'Текущая дата' },
+    type: 'text',
+    value: '',
+  },
+  'Current time': {
+    title: { en: 'Current time', ru: 'Текущее время' },
+    type: 'text',
+    value: '',
+  },
+};
+
+function _system_time_update_datetime() {
+  runShellCommand('date +"%Z (UTC%z)|%Y-%m-%d|%H:%M"', {
+    captureOutput: true,
+    exitCallback: function (exitCode, capturedOutput) {
+      if (exitCode == 0) {
+        var parts = capturedOutput.trim().split('|');
+        if (parts.length === 3) {
+          dev['system-time']['Timezone'] = parts[0];
+          dev['system-time']['Current date'] = parts[1];
+          dev['system-time']['Current time'] = parts[2];
+        } else {
+          log.error('system_time: Failed to parse date output, expected 3 parts but got {}: "{}"', parts.length, capturedOutput.trim());
+        }
+      } else {
+        log.error('system_time: Date command failed with exit code {}, output: "{}"', exitCode, capturedOutput.trim());
+      }
+    }
+  });
+}
+
+defineVirtualDevice('system-time', {
+  title: { en: 'System Time', ru: 'Системное время' },
+  cells: systemTimeCells,
+});
+
+_system_time_update_datetime();
+setInterval(_system_time_update_datetime, 60000);

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -5,22 +5,28 @@
  */
 
 var systemTimeCells = {
-  'timezone': {
-    title: { en: 'Timezone', ru: 'Часовая зона' },
-    type: 'text',
-    order: 3,
-    value: '',
-  },
   'current_date': {
-    title: { en: 'Current date', ru: 'Текущая дата' },
+    title: { en: 'Date', ru: 'Дата' },
     type: 'text',
     order: 1,
     value: '',
   },
-  'current_time': {
-    title: { en: 'Current time', ru: 'Текущее время' },
+  'current_day': {
+    title: { en: 'Day of week', ru: 'День недели' },
     type: 'text',
     order: 2,
+    value: '',
+  },
+  'current_time': {
+    title: { en: 'Time', ru: 'Время' },
+    type: 'text',
+    order: 3,
+    value: '',
+  },
+  'timezone': {
+    title: { en: 'Timezone', ru: 'Часовая зона' },
+    type: 'text',
+    order: 4,
     value: '',
   },
 };
@@ -56,7 +62,7 @@ function _system_time_update_datetime() {
         
         var dateStr = newNow.getFullYear() + '-' + 
                     _padZero(newNow.getMonth() + 1) + '-' + 
-                    _padZero(newNow.getDate()) + ' ' + dayName;
+                    _padZero(newNow.getDate());
         
         var timeStr = _padZero(newNow.getHours()) + ':' + 
                     _padZero(newNow.getMinutes());
@@ -65,6 +71,7 @@ function _system_time_update_datetime() {
         
         dev['system_time']['timezone'] = timezoneStr;
         dev['system_time']['current_date'] = dateStr;
+        dev['system_time']['current_day'] = dayName;
         dev['system_time']['current_time'] = timeStr;
       } catch (error) {
         log.error('system_time: Failed to update datetime in timeout: {}', error.message);

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -13,9 +13,44 @@ var systemTimeCells = {
   },
   'current_day': {
     title: { en: 'Day of week', ru: 'День недели' },
-    type: 'text',
+    type: 'value',
     order: 2,
-    value: '',
+    value: 0,
+    forceDefault: true,
+    enum: {
+      0: {
+        en: 'Not initialized',
+        ru: 'Не инициализировано',
+      },
+      1: {
+        en: 'Monday',
+        ru: 'Понедельник',
+      },
+      2: {
+        en: 'Tuesday',
+        ru: 'Вторник',
+      },
+      3: {
+        en: 'Wednesday',
+        ru: 'Среда',
+      },
+      4: {
+        en: 'Thursday',
+        ru: 'Четверг',
+      },
+      5: {
+        en: 'Friday',
+        ru: 'Пятница',
+      },
+      6: {
+        en: 'Saturday',
+        ru: 'Суббота',
+      },
+      7: {
+        en: 'Sunday',
+        ru: 'Воскресенье',
+      }
+    }
   },
   'current_time': {
     title: { en: 'Time', ru: 'Время' },
@@ -57,8 +92,7 @@ function _system_time_update_datetime() {
         // Get new time (already next minute)
         var newNow = new Date();
         
-        var dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-        var dayName = dayNames[newNow.getDay()];
+        var dayNum = newNow.getDay();
         
         var dateStr = newNow.getFullYear() + '-' + 
                     _padZero(newNow.getMonth() + 1) + '-' + 
@@ -71,7 +105,7 @@ function _system_time_update_datetime() {
         
         dev['system_time']['timezone'] = timezoneStr;
         dev['system_time']['current_date'] = dateStr;
-        dev['system_time']['current_day'] = dayName;
+        dev['system_time']['current_day'] = dayNum;
         dev['system_time']['current_time'] = timeStr;
       } catch (error) {
         log.error('system_time: Failed to update datetime in timeout: {}', error.message);

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -41,20 +41,34 @@ function _system_time_update_datetime() {
   try {
     var now = new Date();
     
-    var dateStr = now.getFullYear() + '-' + 
-                _padZero(now.getMonth() + 1) + '-' + 
-                _padZero(now.getDate());
+    // Calculate time until next minute + 100ms
+    var secondsUntilNextMinute = 60 - now.getSeconds();
+    var millisecondsUntilNextMinute = secondsUntilNextMinute * 1000 - now.getMilliseconds() + 100;
     
-    var timeStr = _padZero(now.getHours()) + ':' + 
-                _padZero(now.getMinutes());
+    // Schedule timer to update at the start of new minute
+    setTimeout(function() {
+      try {
+        // Get new time (already next minute)
+        var newNow = new Date();
+        
+        var dateStr = newNow.getFullYear() + '-' + 
+                    _padZero(newNow.getMonth() + 1) + '-' + 
+                    _padZero(newNow.getDate());
+        
+        var timeStr = _padZero(newNow.getHours()) + ':' + 
+                    _padZero(newNow.getMinutes());
 
-    var timezoneStr = _formatTimezone(now.getTimezoneOffset());
-    
-    dev['system_time']['timezone'] = timezoneStr;
-    dev['system_time']['current_date'] = dateStr;
-    dev['system_time']['current_time'] = timeStr;
+        var timezoneStr = _formatTimezone(newNow.getTimezoneOffset());
+        
+        dev['system_time']['timezone'] = timezoneStr;
+        dev['system_time']['current_date'] = dateStr;
+        dev['system_time']['current_time'] = timeStr;
+      } catch (error) {
+        log.error('system_time: Failed to update datetime in timeout: {}', error.message);
+      }
+    }, millisecondsUntilNextMinute);
   } catch (error) {
-    log.error('system_time: Failed to update datetime: {}', error.message);
+    log.error('system_time: Failed to schedule datetime update: {}', error.message);
   }
 }
 

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -15,12 +15,12 @@ var systemTimeCells = {
     title: { en: 'Day of week', ru: 'День недели' },
     type: 'value',
     order: 2,
-    value: 0,
+    value: 7,
     forceDefault: true,
     enum: {
       0: {
-        en: 'Not initialized',
-        ru: 'Не инициализировано',
+        en: 'Sunday',
+        ru: 'Воскресенье',
       },
       1: {
         en: 'Monday',
@@ -47,8 +47,8 @@ var systemTimeCells = {
         ru: 'Суббота',
       },
       7: {
-        en: 'Sunday',
-        ru: 'Воскресенье',
+        en: 'Not initialized',
+        ru: 'Не инициализировано',
       }
     }
   },


### PR DESCRIPTION
## Связанные PR
- Это устройство нужно для использования в сценари планирования в будующем
https://github.com/wirenboard/wb-scenarios/pull/49

___________________________________
**Что происходит; кому и зачем нужно:**
Добавил новое vd с системным временем, датой и таймзоной обновляющееся раз в минуту. 
Для понимания надобности фичи нужно рассмотреть кейс клиента, который настраивает расписание и не видит реальное системное время из webui, это создает проблемы в случае каких-то несостыковок и лишние вопросы у клиента, поскольку время в браузере может отличаться от контроллера и выполнение cron правил из расписания будет работать неожиданно. Так же нам необходимо чтобы в сценариях когда мы подтягиваем это в vd у нас было один источник


___________________________________
**Что поменялось для пользователей:**
Новое окно системного устройства:
<img width="401" height="222" alt="image" src="https://github.com/user-attachments/assets/7f3a25b7-d817-41f5-9055-48f510766540" />
<img width="412" height="179" alt="image" src="https://github.com/user-attachments/assets/ecbf82f6-b386-4d35-acb6-64c7a1c71919" />



___________________________________
**Как проверял/а:**
На своем  wb8

