### PR TITLE
Add checking for variable changes before pub in system_time.js

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.13.2) stable; urgency=medium
+
+  * system_time.js: don't publish unchanged var
+
+ -- Ilya Tikhonyuk <ilya.tikhonyuk@wirenboard.com>  Wed, 18 Feb 2026 09:48:00 +0300
+
 wb-rules-system (1.13.1) stable; urgency=medium
 
   * power-class-battery: don't publish unchanged "working on battery" status

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -66,6 +66,14 @@ var systemTimeCells = {
   },
 };
 
+//Saving old values
+var lastValues = {
+  current_date: null,
+  current_day: null,
+  current_time: null,
+  timezone: null,
+};
+
 function _padZero(num) {
   var str = String(num);
   return str.length < 2 ? '0' + str : str;
@@ -103,10 +111,26 @@ function _system_time_update_datetime() {
 
         var timezoneStr = _formatTimezone(newNow.getTimezoneOffset());
         
-        dev['system_time']['timezone'] = timezoneStr;
-        dev['system_time']['current_date'] = dateStr;
-        dev['system_time']['current_day'] = dayNum;
-        dev['system_time']['current_time'] = timeStr;
+        if (lastValues.timezone !== timezoneStr) {
+          dev['system_time']['timezone'] = timezoneStr;
+          lastValues.timezone = timezoneStr;
+        }
+
+        if (lastValues.current_date !== dateStr) {
+          dev['system_time']['current_date'] = dateStr;
+          lastValues.current_date = dateStr;
+        }
+
+        if (lastValues.current_day !== dayNum) {
+          dev['system_time']['current_day'] = dayNum;
+          lastValues.current_day = dayNum;
+        }
+
+        if (lastValues.current_time !== timeStr) {
+          dev['system_time']['current_time'] = timeStr;
+          lastValues.current_time = timeStr;
+        }
+
       } catch (error) {
         log.error('system_time: Failed to update datetime in timeout: {}', error.message);
       }


### PR DESCRIPTION
Добавил проверку изменений перед публикацией значений в файле system_time.js

Теперь в виджет "Системное время" публикуются только те данные, которые действительно изменились и не публикуются лишний раз, если нет изменений.

Проверял на столе, на контроллере WB 8.5.

Тикет в ютрак: [INT-807](https://wirenboard.youtrack.cloud/issue/INT-807/Sistemnoe-ustrojstvo-Sistemnoe-vremya-popravit-publikaciyu)


