### PR TITLE
hwmon: add control title translations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.13.4) stable; urgency=medium
+
+  * hwmon: add control title translations
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 13 Mar 2026 18:20:00 +0400
+
 wb-rules-system (1.13.3) stable; urgency=medium
 
   * system_time.js: don't publish unchanged var

--- a/rules/hwmon.js
+++ b/rules/hwmon.js
@@ -18,6 +18,11 @@ function createControlOrSetValue(vdevObj, controlName, controlDesc, initialValue
 }
 
 var nodeInfo = {};
+var translations = {
+  'Battery Temperature': 'Температура батареи',
+  'Board Temperature': 'Температура платы',
+  'CPU Temperature': 'Температура процессора'
+};
 
 runShellCommand(
   'test -d /sys/class/power_supply/wbec-battery',
@@ -62,7 +67,11 @@ runShellCommand(
       for (var nodeName in nodeInfo) {
         if (nodeInfo.hasOwnProperty(nodeName)) {
           var node = nodeInfo[nodeName];
-          cells[node['title']] = { type: 'temperature', value: 0.0 };
+          var title = node['title']
+          cells[title] = { type: 'temperature', value: 0.0 };
+          if (translations[title]) {
+            cells[title]['title'] = { en: title, ru: translations[title] }
+          }
         }
       }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
<img width="549" height="156" alt="Screen Shot 2026-03-14 at 00 26 01" src="https://github.com/user-attachments/assets/b317d562-a93e-4c44-bd69-93c2b0a87e5e" />


___________________________________
**Что поменялось для пользователей:**
добавились переводы

___________________________________
**Как проверял/а:**
на вб

