### PR TITLE
network: strip trailing newline in control value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.13.5) stable; urgency=medium
+
+  * network: strip trailing newline in control value
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 18 Mar 2026 18:20:00 +0400
+
 wb-rules-system (1.13.4) stable; urgency=medium
 
   * hwmon: add control title translations

--- a/rules/network.js
+++ b/rules/network.js
@@ -131,7 +131,7 @@ function _system_update_ip(name, iface) {
     {
       captureOutput: true,
       exitCallback: function (exitCode, capturedOutput) {
-        dev.network[name] = capturedOutput;
+        dev.network[name] = capturedOutput.trim();
       },
     }
   );


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
До:
```sh
/devices/network/controls/Wi-Fi IP	192.168.42.1\

/devices/network/controls/Wi-Fi IP Connection Enabled	1
/devices/network/controls/Wi-Fi IP Online Status	0
```

После:
```sh
/devices/network/controls/Wi-Fi IP	192.168.42.1
/devices/network/controls/Wi-Fi IP Connection Enabled	1
/devices/network/controls/Wi-Fi IP Online Status	0
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
локально

