### PR TITLE
Add GPU Temperature translation to hwmon.js

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-rules-system (1.13.7) stable; urgency=medium
 
   * hwmon: Add GPU Temperature translation
 
- -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 06 Aug 2026 19:43:00 +0300wb-rules-system (1.13.6) stable; urgency=medium
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 06 Aug 2026 19:43:00 +0300
 
   * postinst: use try-restart and ignore restart failures
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,4 @@
-wb-rules-system (1.13.7) stable; urgency=medium
-
-  * hwmon: Add GPU Temperature translation
-
- -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 06 Aug 2026 19:43:00 +0300
+wb-rules-system (1.13.6) stable; urgency=medium
 
   * postinst: use try-restart and ignore restart failures
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,8 @@
-wb-rules-system (1.13.6) stable; urgency=medium
+wb-rules-system (1.13.7) stable; urgency=medium
+
+  * hwmon: Add GPU Temperature translation
+
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 06 Aug 2026 19:43:00 +0300wb-rules-system (1.13.6) stable; urgency=medium
 
   * postinst: use try-restart and ignore restart failures
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules-system (1.13.7) stable; urgency=medium
+
+  * hwmon: Add GPU Temperature translation
+
+ -- Andrey Ksenofontov <andrey.ksenofontov@wirenboard.com>  Thu, 06 Aug 2026 19:43:00 +0300
+ 
 wb-rules-system (1.13.6) stable; urgency=medium
 
   * postinst: use try-restart and ignore restart failures

--- a/rules/hwmon.js
+++ b/rules/hwmon.js
@@ -21,7 +21,8 @@ var nodeInfo = {};
 var translations = {
   'Battery Temperature': 'Температура батареи',
   'Board Temperature': 'Температура платы',
-  'CPU Temperature': 'Температура процессора'
+  'CPU Temperature': 'Температура процессора',
+  'GPU Temperature': 'Температура графического процессора'
 };
 
 runShellCommand(


### PR DESCRIPTION
У восьмёрок появился монитор температуры GPU,  а перевод забыли
Было:

<img width="824" height="310" alt="image" src="https://github.com/user-attachments/assets/46b5443a-3710-4229-a57e-9f1f846dcbd2" />

Стало:
<img width="407" height="366" alt="image" src="https://github.com/user-attachments/assets/352c6380-ab53-4ad0-99a4-06491bef059c" />

___________________________________
**Что поменялось для пользователей:**

Появился перевод для GPU
___________________________________
**Как проверял/а:**

На контроллере WB8.
