### PR TITLE
Fix wb-rules type-checker (checkJs) findings in the shipped rules

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+wb-rules-system (1.13.8) stable; urgency=medium
+
+  * Fix findings of the wb-rules type checker (checkJs) in the shipped rules:
+    - power-class-battery: declare psName (was an implicit global)
+    - buzzer: compute PWM period/duty with an explicit integer truncation
+      instead of parseInt(number) (ES5, works on every wb-rules version)
+    - hwmon: do not redeclare nodeName with a different type in one function
+    - system, system_time, wbmz-battery: annotate cell specs as ControlsSpec so
+      they type-check against the wb-rules control types
+
+ -- Evgeny Boger <boger@wirenboard.com>  Tue, 18 Aug 2026 18:49:57 +0000
+
 wb-rules-system (1.13.7) stable; urgency=medium
 
   * hwmon: Add GPU Temperature translation

--- a/rules/buzzer.js
+++ b/rules/buzzer.js
@@ -60,9 +60,19 @@
     },
   });
 
+  // Integer truncation toward zero, like parseInt(number) did by way of
+  // stringifying its argument (which also turned Infinity into NaN - kept:
+  // frequency is a range that can be 0, and 1/0 must still give period 0).
+  // ES5 only on purpose: Math.trunc does not exist on Duktape (wb-rules < 2.47).
+  function _buzzer_trunc(x) {
+    if (!isFinite(x)) return NaN;
+    return x < 0 ? Math.ceil(x) : Math.floor(x);
+  }
+
   function _buzzer_set_params(exitCallback) {
-    var period = parseInt((1.0 / dev.buzzer.frequency) * 1e9) || 0;
-    var duty_cycle = parseInt(((dev.buzzer.volume * 1.0) / 100) * period * 0.5);
+    // integer nanoseconds
+    var period = _buzzer_trunc((1.0 / dev.buzzer.frequency) * 1e9) || 0;
+    var duty_cycle = _buzzer_trunc(((dev.buzzer.volume * 1.0) / 100) * period * 0.5);
 
     if (!exitCallback) {
         exitCallback = function () {};

--- a/rules/buzzer.js
+++ b/rules/buzzer.js
@@ -63,6 +63,9 @@
   // Integer truncation toward zero, like parseInt(number) did by way of
   // stringifying its argument (which also turned Infinity into NaN - kept:
   // frequency is a range that can be 0, and 1/0 must still give period 0).
+  // Identical to the old expression for every value String(x) prints
+  // positionally (1e-6 <= |x| < 1e21, i.e. all physically meaningful inputs);
+  // beyond that parseInt read only the mantissa digits of the exponent form.
   // ES5 only on purpose: Math.trunc does not exist on Duktape (wb-rules < 2.47).
   function _buzzer_trunc(x) {
     if (!isFinite(x)) return NaN;

--- a/rules/hwmon.js
+++ b/rules/hwmon.js
@@ -65,9 +65,9 @@ runShellCommand(
       }
 
       var cells = {};
-      for (var nodeName in nodeInfo) {
-        if (nodeInfo.hasOwnProperty(nodeName)) {
-          var node = nodeInfo[nodeName];
+      for (var nodeKey in nodeInfo) {
+        if (nodeInfo.hasOwnProperty(nodeKey)) {
+          var node = nodeInfo[nodeKey];
           var title = node['title']
           cells[title] = { type: 'temperature', value: 0.0 };
           if (translations[title]) {

--- a/rules/hwmon.js
+++ b/rules/hwmon.js
@@ -64,6 +64,7 @@ runShellCommand(
         }
       }
 
+      /** @type {ControlsSpec} */
       var cells = {};
       for (var nodeKey in nodeInfo) {
         if (nodeInfo.hasOwnProperty(nodeKey)) {
@@ -139,9 +140,9 @@ function readChannel(path, sysfsPath, controlName) {
 }
 
 function initReadRules() {
-  for (var nodeName in nodeInfo) {
-    if (nodeInfo.hasOwnProperty(nodeName)) {
-      var node = nodeInfo[nodeName];
+  for (var nodeKey in nodeInfo) {
+    if (nodeInfo.hasOwnProperty(nodeKey)) {
+      var node = nodeInfo[nodeKey];
 
       var sysfsDirPath = sysfsMapping[node['hwmon-node-name']];
       if (sysfsDirPath) {

--- a/rules/power-class-battery.js
+++ b/rules/power-class-battery.js
@@ -63,7 +63,7 @@ function collectData() {
 
       // remove power supplies which are no longer present
       Object.keys(powerSupplyNamesByType).forEach(function (psType) {
-        psName = powerSupplyNamesByType[psType];
+        var psName = powerSupplyNamesByType[psType];
         if (newPowerSupplyList.indexOf(psName) == -1) {
           delete powerSupplyNamesByType[psType];
         }

--- a/rules/system.js
+++ b/rules/system.js
@@ -1,3 +1,4 @@
+/** @type {ControlsSpec} */
 var systemCells = {
   'Current uptime': {
     title: { en: 'Current uptime', ru: 'Время работы' },

--- a/rules/system_time.js
+++ b/rules/system_time.js
@@ -4,6 +4,7 @@
  * @author Ivan Praulov <ivan.praulov@wirenboard.com>
  */
 
+/** @type {ControlsSpec} */
 var systemTimeCells = {
   'current_date': {
     title: { en: 'Date', ru: 'Дата' },

--- a/rules/wbmz-battery.js
+++ b/rules/wbmz-battery.js
@@ -36,6 +36,7 @@ function updatePowerStatus(newCurrent) {
 function initDevice(resetButon) {
   /*Инициализация модуля*/
   runShellCommand('i2cset -y {} 0x70 0x00 0x10'.format(config.bus));
+  /** @type {ControlsSpec} */
   var cells = {
     Percentage: {
       type: 'value',


### PR DESCRIPTION
## Why

wb-rules (the QuickJS/TypeScript branch, PRs wirenboard/wb-rules#223/#224) now runs a background TypeScript check over `.js` rule files too (`checkJs`, advisory). The shipped system rules were the first thing it flagged on every controller. This PR fixes the real findings and makes the cell specs type-check — **without changing runtime behavior**, and in **ES5 only**: these rules also run on the Duktape engine of stable wb-rules 2.46.x (`Depends: wb-rules (>= 2.20.0~~)` stays valid).

## What

| File | Change | Finding |
|---|---|---|
| `rules/power-class-battery.js` | `var psName` in the forEach callback | implicit global (worked only because rule files run in sloppy mode) |
| `rules/buzzer.js` | explicit integer truncation helper instead of `parseInt(number)` for the PWM period/duty | `parseInt` stringifies its argument first; the helper keeps the exact semantics (toward zero, `Infinity`/`NaN` → `NaN`, so frequency 0 still yields period 0). ES5 on purpose — `Math.trunc` does not exist on Duktape 1.0.2 |
| `rules/hwmon.js` | rename the for-in loop key | `nodeName` was redeclared with a different inferred type in the same function |
| `rules/system.js`, `rules/system_time.js`, `rules/wbmz-battery.js` | `/** @type {ControlsSpec} */` on the cell-spec vars | the specs are built in a `var` and passed later, so the string literals widened and no longer matched the `ControlOptions` union; the annotation keeps them narrow and type-checks the later per-cell assignments too. No new findings surfaced — every shipped cell spec is valid as-is |
| `debian/changelog` | 1.13.8 | |

**Deliberately left:** `rules/power-class-battery.js:130` (`new Date() - chargingStateSetTime`) — the throttle is dead code (`chargingStateSetTime` is never assigned). Whether to delete it or make it work is a behavior decision for the maintainer; wb-rules no longer reports Date arithmetic in `.js` files anyway.

## Verification

- `tsgo --checkJs` over every file with `types/wb-rules.d.ts`: before — 9 diagnostics in 6 files; after — only the deliberately-left line 130 (which the engine filters for `.js`).
- buzzer math: brute-forced against the old expression (ints 0..7000 × 0..100, fractional sweep, millions of random values incl. negative/NaN/undefined/null/±Infinity) comparing the printed period/duty — identical for every value `String(x)` prints positionally (1e-6 ≤ |x| < 1e21, i.e. all physically meaningful inputs; beyond that the old `parseInt` read only the mantissa digits of the exponent form, the new code is exact). Verified on node and on the real Duktape 1.0.2 engine.
- Duktape compatibility: `Math.trunc`/`Math.sign` confirmed absent on the wb-rules 2.46 engine (probed directly); the helper uses only `isFinite`/`Math.floor`/`Math.ceil`.
- Deployed on a wb-rules 2.47 controller: all vdevs come up with values, zero runtime errors, zero type-check warnings for these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvpkTQYSS1c78EpBCpLTpB

## Verified on the old engine too

Installed on a controller downgraded to **wb-rules 2.46.4 (Duktape 1.0.2)** together with these rules: no load errors; `system`, `system_time`, `hwmon` (renamed loop), `buzzer`, `power_status` all publish values; with the buzzer enabled at volume 0 (silent) the rule wrote exactly the truncated periods to the PWM sysfs — 3000 Hz → `period=333333`, 2000 Hz → `500000`, `duty_cycle=0` — i.e. the ES5 helper behaves like the old `parseInt` on the old engine. Then re-upgraded to 2.47 (QuickJS) with the same files: same results.