### PR TITLE
network: fix connection status for GPRS and the current internet connection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-rules-system (1.13.9) stable; urgency=medium
+
+  * network: report GPRS/ppp connections as enabled (state is UNKNOWN for them,
+    so check the LOWER_UP flag instead)
+  * network: match the internet connection by its IP interface, so that a GSM
+    connection is recognised, and clear the control when nothing matches
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Fri, 04 Sep 2026 12:32:07 +0300
+
 wb-rules-system (1.13.8) stable; urgency=medium
 
   * Fix findings of the wb-rules type checker (checkJs) in the shipped rules:

--- a/rules/network.js
+++ b/rules/network.js
@@ -141,23 +141,34 @@ function _system_update_ip(name, iface) {
       dev.network[name + ' Online Status'] = exitCode === 0;
     },
   });
-  runShellCommand("ip link show {} 2>/dev/null | awk '{for (i=1; i<=NF; i++) if ($i == \"state\") print $(i+1)}'".format(iface), {
-    captureOutput: true,
-    exitCallback: function (exitCode, capturedOutput) {
-      dev.network[name + ' Connection Enabled'] = capturedOutput.trim() === "UP";
-    },
-  });
+  // ppp and other point-to-point interfaces stay at "state UNKNOWN" while running,
+  // so look at the LOWER_UP flag instead: it is set exactly when the link is up
+  runShellCommand(
+    "ip link show {} 2>/dev/null | head -n1 | grep -qE '<[^>]*(,|<)LOWER_UP(,|>)'".format(iface),
+    {
+      captureOutput: false,
+      exitCallback: function (exitCode) {
+        dev.network[name + ' Connection Enabled'] = exitCode === 0;
+      },
+    }
+  );
 }
 
 function _current_active_connection() {
   runShellCommand("ip route get {} 2>/dev/null | grep -oP 'dev\\s+\\K[^ ]+'".format(checkAddress), {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
-      dev.network['Default Interface'] = exitCode === 0 ? capturedOutput.trim() : '';
+      var default_interface = exitCode === 0 ? capturedOutput.trim() : '';
+      dev.network['Default Interface'] = default_interface;
+      // the connection list is read here, not in parallel,
+      // so that it always sees the interface resolved above
+      _update_active_connections(default_interface);
     },
   });
+}
 
-  runShellCommand('nmcli -t -f DEVICE,NAME c s -a 2>/dev/null', {
+function _update_active_connections(default_interface) {
+  runShellCommand('nmcli -t -f NAME,UUID c s -a 2>/dev/null', {
     captureOutput: true,
     exitCallback: function (exitCode, capturedOutput) {
       if (exitCode != 0) {
@@ -166,18 +177,52 @@ function _current_active_connection() {
         return;
       }
       var lines = capturedOutput.split('\n');
-      var active_connections = [];
-      for (var i = 0; i < lines.length - 1; i++) {
-        var dev_name = lines[i].split(':')[0].trim();
-        var con_name = lines[i].split(':')[1].trim();
-        active_connections.push(con_name);
-        if (dev_name === dev.network['Default Interface']) {
-          dev.network['Internet Connection'] = con_name;
+      var connections = [];
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        if (line === '') {
+          continue;
         }
+        // nmcli escapes colons inside a name, the uuid never has any: split at the last one
+        var separator = line.lastIndexOf(':');
+        connections.push({ name: line.slice(0, separator).trim(), uuid: line.slice(separator + 1).trim() });
       }
-      dev.network['Active Connections'] = JSON.stringify(active_connections.sort());
+      var names = [];
+      for (var j = 0; j < connections.length; j++) {
+        names.push(connections[j].name);
+      }
+      dev.network['Active Connections'] = JSON.stringify(names.sort());
+      _update_internet_connection(connections, default_interface);
     },
   });
+}
+
+function _update_internet_connection(connections, default_interface) {
+  if (default_interface === '' || connections.length === 0) {
+    dev.network['Internet Connection'] = '';
+    return;
+  }
+  // NetworkManager reports the modem port (ttyUSB1) as the device of a GSM connection
+  // while the routes live on ppp0, so match by the interface carrying the IP configuration
+  var pending = connections.length;
+  var found = '';
+  for (var i = 0; i < connections.length; i++) {
+    (function (connection) {
+      runShellCommand("nmcli -t -f GENERAL.IP-IFACE c s {} 2>/dev/null".format(connection.uuid), {
+        captureOutput: true,
+        exitCallback: function (exitCode, capturedOutput) {
+          var ip_iface = capturedOutput.split(':')[1];
+          if (exitCode === 0 && ip_iface !== undefined && ip_iface.trim() === default_interface) {
+            found = connection.name;
+          }
+          pending -= 1;
+          if (pending === 0) {
+            dev.network['Internet Connection'] = found;
+          }
+        },
+      });
+    })(connections[i]);
+  }
 }
 
 function _system_update_ip_all() {


### PR DESCRIPTION
## Проблема

С поднятым и работающим модемом контрол **«GPRS IP Включен»** всегда выключен. Заявлено в [теме на форуме](https://support.wirenboard.com/t/wiren-board-gprs-ip/41383): ppp0 в состоянии `UP,LOWER_UP`, адрес получен, трафик ходит, `GPRS IP Online Status` = 1 — а `Connection Enabled` = 0.

Рядом нашёлся второй дефект: после переключения маршрута по умолчанию на модем контрол **«Интернет соединение»** продолжает показывать Ethernet-соединение.

## Причины

**Connection Enabled.** Проверялось поле `state` из `ip link show`:

```
eth0  <BROADCAST,MULTICAST,UP,LOWER_UP>            state UP
wlan0 <BROADCAST,MULTICAST,UP,LOWER_UP>            state UP
ppp0  <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP>    state UNKNOWN   ← сравнение с "UP" ложно
eth1  <NO-CARRIER,BROADCAST,MULTICAST,UP>          state DOWN
```

У point-to-point интерфейсов ядро operstate не заполняет, поэтому для ppp сравнение с `"UP"` ложно всегда.

**Internet Connection.** Имя соединения искалось сопоставлением `Default Interface` (из `ip route get`, то есть `ppp0`) с устройством из `nmcli`, а для GSM это порт модема:

```
eth0:wb-eth0
ttyUSB1:wb-gsm-sim1
```

Совпадения не будет никогда, а при его отсутствии значение не сбрасывалось — контрол молча сохранял прежнее.

## Решение

`LOWER_UP` вместо `state`: флаг стоит ровно тогда, когда линк поднят, что чинит ppp и сохраняет текущее поведение для Ethernet и Wi-Fi — у eth1 без кабеля `LOWER_UP` нет.

Сопоставление по `GENERAL.IP-IFACE` — интерфейсу, на котором реально живёт IP-конфигурация (для GSM это `ppp0`), плюс сброс контрола, когда совпадений нет. Соединения запрашиваются по uuid, что заодно защищает разбор от имён с двоеточием.

Список соединений читается внутри колбэка, определяющего интерфейс по умолчанию, а не параллельно с ним — раньше он мог увидеть прежнее значение.

Код остаётся ES5 ради Duktape, как и договаривались в #65: обычные `for`, IIFE для замыкания, без `let`/`const` и стрелок.

## Проверка

На контроллере с модемом (SIMCom A7602E-H, wb-rules 2.40.0 — движок Duktape), правило отработало без ошибок:

| | было | стало |
|---|---|---|
| `GPRS IP Connection Enabled` | 0 | **1** |
| `Internet Connection`, маршрут через ppp0 | wb-eth0 | **wb-gsm-sim1** |
| `Internet Connection`, обратно на eth0 | — | **wb-eth0** |
| `Ethernet 2 Connection Enabled`, без кабеля | 0 | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)